### PR TITLE
Fix: 부모 문서 id 및 일관성 에러 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from modules.retriever import AdvancedRetriever
 from modules.llm_handler import LLMHandler
 from langchain.storage import InMemoryStore # --- 추가된 부분 ---
 
+from modules.utils_docstore import register_parent_docs
+
 # --- 추가/수정된 부분 ---
 def main(rebuild_db: bool, until_step: str):
     """
@@ -54,7 +56,7 @@ def main(rebuild_db: bool, until_step: str):
 
     # --- 이하 코드는 until_step == 'run' 일 때만 실행됩니다. ---
     
-     # 3. 벡터 DB 구축 또는 로드
+    # 3. 벡터 DB 구축 또는 로드
     print("\n--- 3. 벡터 DB 준비 시작 ---")
     vs_manager = VectorStoreManager()
     
@@ -70,8 +72,7 @@ def main(rebuild_db: bool, until_step: str):
         # (InMemoryStore는 휘발성이므로 프로그램을 켤 때마다 채워야 함)
         vectorstore = vs_manager.load()
         parent_documents = vs_manager._load_documents_from_json(config.MERGED_PREPROCESSED_FILE)
-        doc_ids = [doc.metadata["doc_id"] for doc in parent_documents] # build시 저장했던 부모 문서의 메타 데이터에서 id를 가져온다 
-        docstore.mset(list(zip(doc_ids, parent_documents))) # docstore에 id-문서(value) 저장
+        register_parent_docs(docstore, parent_documents) # docstore에 부모 문서 저장
 
     if not vectorstore:
         print("CRITICAL: 벡터 DB 준비에 실패하여 프로그램을 종료합니다.")

--- a/modules/utils_docstore.py
+++ b/modules/utils_docstore.py
@@ -1,0 +1,54 @@
+# modules/utils_docstore.py
+import uuid
+from langchain.docstore.document import Document
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+def compute_doc_id(md: dict) -> str:
+    """
+    항상 같은 입력 → 같은 doc_id 반환
+    우선순위: url > (title|ingredients) > 원본 id > fallback
+    """
+    key = (
+        md.get("url")
+        or (md.get("title", "") + "|" + md.get("ingredients", "")).strip()
+        or md.get("id", "")
+    )
+    if not key:
+        key = "fallback|" + uuid.uuid4().hex
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, key))
+
+def register_parent_docs(docstore, parent_documents):
+    """
+    부모 문서에 doc_id 부여 후 docstore에 저장
+    Returns:
+        list[str]: 부여된 doc_id 리스트
+    """
+    doc_ids = []
+    for doc in parent_documents:
+        doc.metadata["doc_id"] = compute_doc_id(doc.metadata)
+        doc_ids.append(doc.metadata["doc_id"])
+    docstore.mset(list(zip(doc_ids, parent_documents)))
+    return doc_ids
+
+def make_child_chunks(parent_documents, chunk_size=400, chunk_overlap=60):
+    """
+    부모 문서를 잘게 쪼개서 자식 청크를 생성하고,
+    각 자식의 메타데이터에 부모의 doc_id를 복사한다.
+    
+    Args:
+        parent_documents (List[Document]): 부모 문서 리스트
+        chunk_size (int): 청크 크기
+        chunk_overlap (int): 청크 겹침
+    
+    Returns:
+        List[Document]: 자식 청크 문서 리스트
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap
+    )
+    children = []
+    for p in parent_documents:
+        for ch in splitter.split_documents([p]):
+            ch.metadata["doc_id"] = p.metadata["doc_id"]
+            children.append(ch)
+    return children


### PR DESCRIPTION
1. 부모 doc_id Json에 저장되어 있지 않아서 생긴 런타임 에러 수정
원본 Json에 저장하지 않고 meta data url 사용해서 항상 같은 id 생성하도록 변경
2. doc_id 관련 기능 util 파일로 분리